### PR TITLE
Add --pluginsdir flag.

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -20,7 +20,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -57,6 +57,9 @@ const (
 var (
 	// flags that configure the node
 	nodeFlags = flags.Merge([]cli.Flag{
+		//begin PluGeth code injection
+		utils.PluginsDirFlag,
+		//end PluGeth code injection
 		utils.IdentityFlag,
 		utils.UnlockedAccountFlag,
 		utils.PasswordFileFlag,
@@ -336,7 +339,14 @@ func prepare(ctx *cli.Context) {
 // blocking mode, waiting for it to be shut down.
 func geth(ctx *cli.Context) error {
 	//begin PluGeth code injection
-	if err := plugins.Initialize(path.Join(ctx.String(utils.DataDirFlag.Name), "plugins"), ctx); err != nil {
+	var pluginsDir string
+	if ctx.IsSet(utils.PluginsDirFlag.Name) {
+		pluginsDir = ctx.String(utils.PluginsDirFlag.Name)
+	} else {
+		pluginsDir = filepath.Join(ctx.String(utils.DataDirFlag.Name), "plugins")
+	}
+
+	if err := plugins.Initialize(pluginsDir, ctx); err != nil {
 		return err
 	}
 	prepare(ctx)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -88,6 +88,14 @@ import (
 
 var (
 	// General settings
+	//begin PluGeth code injection
+	PluginsDirFlag = &flags.DirectoryFlag{
+		Name:     "pluginsdir",
+		Usage:    "Directory for plugins",
+		Value:    flags.DirectoryString(filepath.Join("<datadir>", "plugins")),
+		Category: flags.EthCategory,
+	}
+	//end PluGeth code injection
 	DataDirFlag = &flags.DirectoryFlag{
 		Name:     "datadir",
 		Usage:    "Data directory for the databases and keystore",

--- a/plugins/plugin_loader.go
+++ b/plugins/plugin_loader.go
@@ -8,7 +8,7 @@ import (
 	"plugin"
 	"reflect"
 	"strings"
-	
+
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/openrelayxyz/plugeth-utils/core"
@@ -58,6 +58,7 @@ func Lookup(name string, validate func(interface{}) bool) []interface{} {
 var DefaultPluginLoader *PluginLoader
 
 func NewPluginLoader(target string) (*PluginLoader, error) {
+	log.Info("Loading plugins from directory", "path", target)
 	pl := &PluginLoader{
 		Plugins:     []pluginDetails{},
 		Subcommands: make(map[string]Subcommand),


### PR DESCRIPTION
Add a new flag, `--pluginsdir`, for setting the directory where plugins are stored.  The default remains `$datadir/plugins`.
