### PR TITLE
Fixed a patch in the engine wrapper.

### DIFF
--- a/plugins/wrappers/engine/enginewrapper.go
+++ b/plugins/wrappers/engine/enginewrapper.go
@@ -381,7 +381,7 @@ func (ew *engineWrapper) VerifyHeaders(chain consensus.ChainHeaderReader, header
 	for i, header := range headers {
 		pheaders[i] = gethToUtilsHeader(header)
 	}
-	dummySeals := []bool{false, false}
+	dummySeals := make([]bool, len(headers))
 	return ew.engine.VerifyHeaders(&WrappedHeaderReader{chain, nil}, pheaders, dummySeals)
 }
 func (ew *engineWrapper) VerifyUncles(chain consensus.ChainReader, block *types.Block) error {


### PR DESCRIPTION
In order to keep our utils interfaces as generic as possible across chains I added a "dummySeals" []bool to the engine wrapper. Up until now the slice was a fixed size. From this point it has the same length as the []*headers argument also passed into the same function.