### PR TITLE
Use the statedb database to get Tries

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -358,8 +358,7 @@ func geth(ctx *cli.Context) error {
 	}
 
 	stack, backend := makeFullNode(ctx)
-	trieCfg := plugethCaptureTrieConfig(ctx, stack, backend)
-	wrapperBackend := backendwrapper.NewBackend(backend, trieCfg)
+	wrapperBackend := backendwrapper.NewBackend(backend)
 
 	pluginsInitializeNode(stack, wrapperBackend)
 	if ok, err := plugins.RunSubcommand(ctx); ok {

--- a/cmd/geth/plugin_hooks.go
+++ b/cmd/geth/plugin_hooks.go
@@ -1,25 +1,15 @@
 package main
 
 import (
-	"github.com/ethereum/go-ethereum/cmd/utils"
-	gcore "github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/eth/ethconfig"
-	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/node"
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/ethereum/go-ethereum/trie"
-	"github.com/ethereum/go-ethereum/trie/triedb/hashdb"
-	"github.com/ethereum/go-ethereum/trie/triedb/pathdb"
 	
 	"github.com/ethereum/go-ethereum/plugins"
 	"github.com/ethereum/go-ethereum/plugins/wrappers"
 	
 	"github.com/openrelayxyz/plugeth-utils/core"
 	"github.com/openrelayxyz/plugeth-utils/restricted"
-
-	"github.com/urfave/cli/v2"
 )
 
 func apiTranslate(apis []core.API) []rpc.API {
@@ -131,70 +121,4 @@ func pluginBlockChain() {
 			return
 	}
 	BlockChain(plugins.DefaultPluginLoader)
-}
-
-func plugethCaptureTrieConfig(ctx *cli.Context, stack *node.Node, backend ethapi.Backend) *trie.Config {
-
-	ethCfg := new(ethconfig.Config)
-
-	if ctx.IsSet(utils.CacheFlag.Name) || ctx.IsSet(utils.CacheTrieFlag.Name) {
-		ethCfg.TrieCleanCache = ctx.Int(utils.CacheFlag.Name) * ctx.Int(utils.CacheTrieFlag.Name) / 100
-	}
-	if ctx.IsSet(utils.CacheNoPrefetchFlag.Name) {
-		ethCfg.NoPrefetch = ctx.Bool(utils.CacheNoPrefetchFlag.Name)
-	}
-	if ctx.IsSet(utils.CacheFlag.Name) || ctx.IsSet(utils.CacheGCFlag.Name) {
-		ethCfg.TrieDirtyCache = ctx.Int(utils.CacheFlag.Name) * ctx.Int(utils.CacheGCFlag.Name) / 100
-	}
-	if ctx.IsSet(utils.GCModeFlag.Name) {
-		ethCfg.NoPruning = ctx.String(utils.GCModeFlag.Name) == "archive"
-	}
-	if ctx.IsSet(utils.CacheFlag.Name) || ctx.IsSet(utils.CacheSnapshotFlag.Name) {
-		ethCfg.SnapshotCache = ctx.Int(utils.CacheFlag.Name) * ctx.Int(utils.CacheSnapshotFlag.Name) / 100
-	}
-	ethCfg.Preimages = ctx.Bool(utils.CachePreimagesFlag.Name)
-	if ethCfg.NoPruning && !ethCfg.Preimages {
-		ethCfg.Preimages = true
-		log.Info("Enabling recording of key preimages since archive mode is used")
-	}
-	if ctx.IsSet(utils.StateHistoryFlag.Name) {
-		ethCfg.StateHistory = ctx.Uint64(utils.StateHistoryFlag.Name)
-	}
-
-	chaindb := backend.ChainDb()
-
-	scheme, err := rawdb.ParseStateScheme(ctx.String(utils.StateSchemeFlag.Name), chaindb)
-	if err != nil {
-		utils.Fatalf("%v", err)
-	} 
-
-	ethCfg.StateScheme = scheme
-	
-	cacheCfg := &gcore.CacheConfig{
-		TrieCleanLimit:      ethCfg.TrieCleanCache,
-		TrieCleanNoPrefetch: ethCfg.NoPrefetch,
-		TrieDirtyLimit:      ethCfg.TrieDirtyCache,
-		TrieDirtyDisabled:   ethCfg.NoPruning,
-		TrieTimeLimit:       ethconfig.Defaults.TrieTimeout,
-		SnapshotLimit:       ethCfg.SnapshotCache,
-		Preimages:           ethCfg.Preimages,
-		StateHistory:        ethCfg.StateHistory,
-		StateScheme:         ethCfg.StateScheme,
-	}
-
-	config := &trie.Config{Preimages: cacheCfg.Preimages}
-	if cacheCfg.StateScheme == rawdb.HashScheme {
-		config.HashDB = &hashdb.Config{
-			CleanCacheSize: cacheCfg.TrieCleanLimit * 1024 * 1024,
-		}
-	}
-	if cacheCfg.StateScheme == rawdb.PathScheme {
-		config.PathDB = &pathdb.Config{
-			StateHistory:   cacheCfg.StateHistory,
-			CleanCacheSize: cacheCfg.TrieCleanLimit * 1024 * 1024,
-			DirtyCacheSize: cacheCfg.TrieDirtyLimit * 1024 * 1024,
-		}
-	}
-
-	return config
 }

--- a/plugins/wrappers/backendwrapper/triewrapper.go
+++ b/plugins/wrappers/backendwrapper/triewrapper.go
@@ -40,7 +40,9 @@ func (t *WrappedTrie) Hash() core.Hash {
 
 func (t *WrappedTrie) NodeIterator(startKey []byte) core.NodeIterator {
 	itr, err := t.t.NodeIterator(startKey)
-	log.Error("Error returned from geth side NodeIterator", "err", err)
+	if err != nil {
+		log.Error("Error returned from geth side NodeIterator", "err", err)
+	}
 	return &WrappedNodeIterator{itr}
 }
 


### PR DESCRIPTION
The old approach of getting state tries involved instantiating a new state database and using it to instantiate a trie. What we didn't realize was that state database needed to have Close() called on it, which we didn't offer a way for plugins to do, resulting in memory leaking.

This approach reuses the primary trie database associated with the blockchain object, albeit a bit indirectly. This will allow access to recent tries that are stored in memory, where previously only tries that had been committed to disk were accessible.